### PR TITLE
fix: keep Lighting in Newer Versions on by default

### DIFF
--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -181,7 +181,6 @@ export const serverSafeSettings: Partial<Record<keyof typeof defaultOptions, tru
   loadPlayerSkins: true,
   disableBlockEntityTextures: true,
   neighborChunkUpdates: true,
-  newVersionsLighting: true,
   showCursorBlockInSpectator: true,
 }
 export type OptionValueType = string | number | boolean | string[] | Record<string, any> | null

--- a/src/optionsStorage.ts
+++ b/src/optionsStorage.ts
@@ -56,8 +56,29 @@ const migrateOptions = (options: Partial<AppOptions & Record<string, any>>) => {
   }
 
   migrateRendererOptions(options)
+  upgradeNewVersionsLightingDefault(options)
 
   return options
+}
+
+const NEW_VERSIONS_LIGHTING_DEFAULT_MIGRATION_KEY = 'migratedNewVersionsLightingDefault'
+
+function upgradeNewVersionsLightingDefault(saved: Record<string, any>) {
+  let alreadyMigrated = false
+  try {
+    alreadyMigrated = localStorage.getItem(NEW_VERSIONS_LIGHTING_DEFAULT_MIGRATION_KEY) === '1'
+  } catch {
+    alreadyMigrated = false
+  }
+  if (!alreadyMigrated && saved.newVersionsLighting === false) {
+    delete saved.newVersionsLighting
+  }
+  if (alreadyMigrated) return
+  try {
+    localStorage.setItem(NEW_VERSIONS_LIGHTING_DEFAULT_MIGRATION_KEY, '1')
+  } catch {
+    // private mode: next load may upgrade again; that is safe
+  }
 }
 
 export type AppOptions = typeof defaultOptions

--- a/src/watchOptions.ts
+++ b/src/watchOptions.ts
@@ -50,7 +50,7 @@ export const watchOptionsAfterViewerInit = () => {
     applyRendererEnableLighting(
       appViewer,
       options.newVersionsLighting,
-      bot.supportFeature('blockStateId')
+      typeof bot === 'undefined' || !bot ? false : bot.supportFeature('blockStateId')
     )
   })
 


### PR DESCRIPTION
## Summary

- Toggling **Lighting in Newer Versions** in the main menu no longer throws (`bot` is missing there). Protocol probe runs as `false` until a bot exists; `mineflayerBotCreated` still applies the real `blockStateId` check.
- A stored `false` from the previous default is dropped **once** (`localStorage` key `migratedNewVersionsLightingDefault`). After that, an explicit off is kept. The flag is not a user-visible option.
- `newVersionsLighting` is removed from `serverSafeSettings`, so a plugin channel cannot turn lighting off on join.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when checking support for newer lighting features.
  - Prevented errors when feature information is unavailable.
  - Updated saved lighting preferences during migration so outdated settings no longer override current defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->